### PR TITLE
Add stay event

### DIFF
--- a/Starter Code/plagueInc.h
+++ b/Starter Code/plagueInc.h
@@ -18,7 +18,7 @@
 #define NUM_PEOPLE = 50
 
 //Move causes status check, after status check is done move again
-enum events { ARRIVAL, DEPARTURE, NEW_INFECTION, NEW_RECOVERY, STATUS_CHECK};
+enum events { ARRIVAL, DEPARTURE, NEW_INFECTION, NEW_RECOVERY, STAY, STATUS_CHECK};
 enum abs_directions { NORTH = 0, NORTH_EAST, EAST, SOUTH_EAST, SOUTH, SOUTH_WEST, WEST, NORTH_WEST, NO_MOVE};
 
 
@@ -49,6 +49,7 @@ typedef struct {
     bool person_infected;
     tw_lpid person_id;
     int infected_count;
+    person* person_state;
 } Msg_Data;
 
 #endif


### PR DESCRIPTION
## Summary by Sourcery

Add a STAY event to the simulation to track people who remain in their current location

New Features:
- Introduced a new STAY event type to the simulation event enum to handle cases where a person does not move from their current location

Enhancements:
- Modified location and person event handlers to support the new STAY event
- Added a default case in location event handler to handle STAY events

Chores:
- Updated event enum to include STAY as a new event type
- Added a person_state field to the Msg_Data struct